### PR TITLE
Fix serve config parsing

### DIFF
--- a/aviary/backend/server/models.py
+++ b/aviary/backend/server/models.py
@@ -508,7 +508,7 @@ class AppArgs(BaseModel):
 
 
 class RouterArgs(BaseModel):
-    models: Dict[str, Union[str, LLMApp]]
+    models: Union[str, LLMApp, List[Union[LLMApp, str]]]
 
 
 class PlacementConfig(BaseModel):

--- a/aviary/backend/server/run.py
+++ b/aviary/backend/server/run.py
@@ -115,6 +115,7 @@ def router_application(args):
     llm_apps = parse_args(router_args.models, llm_app_cls=VLLMApp)
     return router_deployment(llm_apps, enable_duplicate_models=False)
 
+
 def run(
     vllm_base_args: List[str],
     blocking: bool = False,

--- a/aviary/backend/server/run.py
+++ b/aviary/backend/server/run.py
@@ -7,7 +7,7 @@ from ray import serve
 from aviary.backend.llm.vllm.vllm_engine import VLLMEngine
 from aviary.backend.llm.vllm.vllm_models import VLLMApp
 from aviary.backend.server.app import RouterDeployment
-from aviary.backend.server.models import LLMApp, ScalingConfig, RouterArgs
+from aviary.backend.server.models import LLMApp, RouterArgs, ScalingConfig
 from aviary.backend.server.plugins.deployment_base_client import DeploymentBaseClient
 from aviary.backend.server.plugins.execution_hooks import (
     ExecutionHooks,

--- a/aviary/backend/server/run.py
+++ b/aviary/backend/server/run.py
@@ -7,7 +7,7 @@ from ray import serve
 from aviary.backend.llm.vllm.vllm_engine import VLLMEngine
 from aviary.backend.llm.vllm.vllm_models import VLLMApp
 from aviary.backend.server.app import RouterDeployment
-from aviary.backend.server.models import LLMApp, ScalingConfig
+from aviary.backend.server.models import LLMApp, ScalingConfig, RouterArgs
 from aviary.backend.server.plugins.deployment_base_client import DeploymentBaseClient
 from aviary.backend.server.plugins.execution_hooks import (
     ExecutionHooks,
@@ -111,9 +111,9 @@ def router_deployment(
 
 
 def router_application(args):
-    llm_apps = parse_args(args, llm_app_cls=VLLMApp)
+    router_args = RouterArgs.parse_obj(args)
+    llm_apps = parse_args(router_args.models, llm_app_cls=VLLMApp)
     return router_deployment(llm_apps, enable_duplicate_models=False)
-
 
 def run(
     vllm_base_args: List[str],


### PR DESCRIPTION
This seems to have been accidentally removed in [previous PR](https://github.com/ray-project/ray-llm/pull/62/files#diff-5533e3d1081ea5213049eb49d4e358cdb0dbcab9a0bcc93b8d9999033dff3e48L149)
serve config.yaml [expects args to be dictionary](https://github.com/ray-project/ray/blob/master/python/ray/serve/schema.py#L383). See existing readme in [ray-llm repo](https://github.com/ray-project/ray-llm#how-do-i-deploy-multiple-models-at-once)

Accidentally remove RouterArgs parsing is causing the following issue
```
pydantic.error_wrappers.ValidationError: 2 validation errors for VLLMApp
engine_config
  field required (type=value_error.missing)
scaling_config
  field required (type=value_error.missing)
```


Tested locally with following serve config and verified with fix i am able to start server

```
applications:
- name: meta-llama--Llama-2-7b-chat-hf
  route_prefix: /
  import_path: aviary.backend:router_application
  args:
    models:
      - "path to model"

```
Looks like others are also facing this: https://ray-distributed.slack.com/archives/C053J39MJ3A/p1696320039604519

