### PR TITLE
Set `route_prefixes` in Serve configs to `/`

### DIFF
--- a/serve_configs/amazon--LightGPT.yaml
+++ b/serve_configs/amazon--LightGPT.yaml
@@ -1,5 +1,5 @@
 applications:
-- name: amazon--LightGPT
+- name: ray-llm
   route_prefix: /
   import_path: aviary.backend:router_application
   args:

--- a/serve_configs/amazon--LightGPT.yaml
+++ b/serve_configs/amazon--LightGPT.yaml
@@ -1,6 +1,6 @@
 applications:
 - name: amazon--LightGPT
-  route_prefix: /amazon--LightGPT
+  route_prefix: /
   import_path: aviary.backend:router_application
   args:
     models:

--- a/serve_configs/codellama--CodeLlama-34b-Instruct-hf.yaml
+++ b/serve_configs/codellama--CodeLlama-34b-Instruct-hf.yaml
@@ -1,6 +1,6 @@
 applications:
 - name: codellama--CodeLlama-34b-Instruct-hf
-  route_prefix: /codellama--CodeLlama-34b-Instruct-hf
+  route_prefix: /
   import_path: aviary.backend:router_application
   args:
     models:

--- a/serve_configs/codellama--CodeLlama-34b-Instruct-hf.yaml
+++ b/serve_configs/codellama--CodeLlama-34b-Instruct-hf.yaml
@@ -1,5 +1,5 @@
 applications:
-- name: codellama--CodeLlama-34b-Instruct-hf
+- name: ray-llm
   route_prefix: /
   import_path: aviary.backend:router_application
   args:

--- a/serve_configs/meta-llama--Llama-2-13b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-13b-chat-hf.yaml
@@ -1,6 +1,6 @@
 applications:
 - name: meta-llama--Llama-2-13b-chat-hf
-  route_prefix: /meta-llama--Llama-2-13b-chat-hf
+  route_prefix: /
   import_path: aviary.backend:router_application
   args:
     models:

--- a/serve_configs/meta-llama--Llama-2-13b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-13b-chat-hf.yaml
@@ -1,5 +1,5 @@
 applications:
-- name: meta-llama--Llama-2-13b-chat-hf
+- name: ray-llm
   route_prefix: /
   import_path: aviary.backend:router_application
   args:

--- a/serve_configs/meta-llama--Llama-2-70b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-70b-chat-hf.yaml
@@ -1,5 +1,5 @@
 applications:
-- name: meta-llama--Llama-2-70b-chat-hf
+- name: ray-llm
   route_prefix: /
   import_path: aviary.backend:router_application
   args:

--- a/serve_configs/meta-llama--Llama-2-70b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-70b-chat-hf.yaml
@@ -1,6 +1,6 @@
 applications:
 - name: meta-llama--Llama-2-70b-chat-hf
-  route_prefix: /meta-llama--Llama-2-70b-chat-hf
+  route_prefix: /
   import_path: aviary.backend:router_application
   args:
     models:

--- a/serve_configs/meta-llama--Llama-2-7b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-7b-chat-hf.yaml
@@ -1,5 +1,5 @@
 applications:
-- name: meta-llama--Llama-2-7b-chat-hf
+- name: ray-llm
   route_prefix: /
   import_path: aviary.backend:router_application
   args:

--- a/serve_configs/meta-llama--Llama-2-7b-chat-hf.yaml
+++ b/serve_configs/meta-llama--Llama-2-7b-chat-hf.yaml
@@ -1,6 +1,6 @@
 applications:
 - name: meta-llama--Llama-2-7b-chat-hf
-  route_prefix: /meta-llama--Llama-2-7b-chat-hf
+  route_prefix: /
   import_path: aviary.backend:router_application
   args:
     models:


### PR DESCRIPTION
The `README` assumes that the `route_prefix` for the RayLLM app is `/`. This change updates the Serve configs to use `/` as the `route_prefix`.