### PR TITLE
fixes cluster yaml to use the correct resource attribute naming 

### DIFF
--- a/deploy/ray/aviary-cluster.yaml
+++ b/deploy/ray/aviary-cluster.yaml
@@ -61,7 +61,7 @@ available_node_types:
     resources:
       worker_node: 1
       instance_type_p4d: 1
-      accelerator_type_a10_40g: 1
+      accelerator_type_a100_40g: 1
     min_workers: 0
     max_workers: 8
   gpu_worker_p4de:
@@ -71,7 +71,7 @@ available_node_types:
     resources:
       worker_node: 1
       instance_type_p4de: 1
-      accelerator_type_a10_80g: 1
+      accelerator_type_a100_80g: 1
     min_workers: 0
     max_workers: 8
   cpu_worker:


### PR DESCRIPTION
Currently, the deployment cluster yaml specifies `accelerator_type_a10_40g` and `accelerator_type_a10_80g` .

However, these resources utilize A100s. This Pr simply updates the naming which is matched in the model deployment configs as well.