### PR TITLE
fix: docker image references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ The guide below walks you through the steps required for deployment of RayLLM on
 
 ### Locally
 
-We highly recommend using the official `anyscale/rayllm` Docker image to run RayLLM. Manually installing RayLLM is currently not a supported use-case due to specific dependencies required, some of which are not available on pip.
+We highly recommend using the official `anyscale/ray-llm` Docker image to run RayLLM. Manually installing RayLLM is currently not a supported use-case due to specific dependencies required, some of which are not available on pip.
 
 ```shell
 cache_dir=${XDG_CACHE_HOME:-$HOME/.cache}
 
-docker run -it --gpus all --shm-size 1g -p 8000:8000 -e HF_HOME=~/data -v $cache_dir:~/data anyscale/rayllm:latest bash
+docker run -it --gpus all --shm-size 1g -p 8000:8000 -e HF_HOME=~/data -v $cache_dir:~/data anyscale/ray-llm:latest bash
 # Inside docker container
 serve run ~/serve_config/amazon--LightGPT.yaml
 ```
@@ -231,7 +231,7 @@ pip install "rayllm[frontend] @ git+https://github.com/ray-project/ray-llm.git"
 ```
 
 The backend dependencies are heavy weight, and quite large. We recommend using the official
-`anyscale/rayllm` image. Installing the backend manually is not a supported usecase.
+`anyscale/ray-llm` image. Installing the backend manually is not a supported usecase.
 
 ## Running Aviary Explorer locally
 

--- a/deploy/ray/rayllm-cluster.yaml
+++ b/deploy/ray/rayllm-cluster.yaml
@@ -7,7 +7,7 @@ provider:
     region: us-west-2
     cache_stopped_nodes: False
 docker:
-    image: "anyscale/rayllm:latest"
+    image: "anyscale/ray-llm:latest"
     container_name: "rayllm"
     run_options:
       - --entrypoint ""

--- a/docs/DOCKERHUB.md
+++ b/docs/DOCKERHUB.md
@@ -42,7 +42,7 @@ docker run \
     --shm-size 1g \
     -p 8000:8000 \
     --entrypoint rayllm \
-    anyscale/rayllm:latest run --model models/continuous_batching/amazon--LightGPT.yaml
+    anyscale/ray-llm:latest run --model models/continuous_batching/amazon--LightGPT.yaml
 ```
 
 # Source

--- a/docs/kuberay/deploy-on-gke.md
+++ b/docs/kuberay/deploy-on-gke.md
@@ -102,7 +102,7 @@ helm repo update
 
 If you are running this tutorial on the Google Cloud Shell, please copy the file `docs/kuberay/ray-cluster.rayllm-gke.yaml` to the Google Cloud Shell. You may find it useful to use the [Cloud Shell Editor](https://cloud.google.com/shell/docs/editor-overview) to edit the file.
 
-Now you can create a RayCluster with RayLLM. RayLLM is included in the image `anyscale/rayllm:latest`, which is specified in the RayCluster YAML manifest `ray-cluster.rayllm-gke.yaml`.
+Now you can create a RayCluster with RayLLM. RayLLM is included in the image `anyscale/ray-llm:latest`, which is specified in the RayCluster YAML manifest `ray-cluster.rayllm-gke.yaml`.
 
 ```sh
 # path: docs/kuberay

--- a/docs/kuberay/ray-cluster.rayllm-eks.yaml
+++ b/docs/kuberay/ray-cluster.rayllm-eks.yaml
@@ -16,7 +16,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: anyscale/rayllm:latest
+          image: anyscale/ray-llm:latest
           resources:
             limits:
               cpu: 2
@@ -45,7 +45,7 @@ spec:
       spec:
         containers:
         - name: llm
-          image: anyscale/rayllm:latest
+          image: anyscale/ray-llm:latest
           lifecycle:
             preStop:
               exec:

--- a/docs/kuberay/ray-cluster.rayllm-gke.yaml
+++ b/docs/kuberay/ray-cluster.rayllm-gke.yaml
@@ -16,7 +16,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: anyscale/rayllm:latest
+          image: anyscale/ray-llm:latest
           resources:
             limits:
               cpu: 2
@@ -45,7 +45,7 @@ spec:
       spec:
         containers:
         - name: llm
-          image: anyscale/rayllm:latest
+          image: anyscale/ray-llm:latest
           lifecycle:
             preStop:
               exec:

--- a/docs/kuberay/ray-service.rayllm-eks.yaml
+++ b/docs/kuberay/ray-service.rayllm-eks.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: anyscale/rayllm:latest
+            image: anyscale/ray-llm:latest
             resources:
               limits:
                 cpu: 2
@@ -59,7 +59,7 @@ spec:
         spec:
           containers:
           - name: llm
-            image: anyscale/rayllm:latest
+            image: anyscale/ray-llm:latest
             lifecycle:
               preStop:
                 exec:

--- a/docs/kuberay/ray-service.rayllm-gke.yaml
+++ b/docs/kuberay/ray-service.rayllm-gke.yaml
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: anyscale/rayllm:latest
+            image: anyscale/ray-llm:latest
             resources:
               limits:
                 cpu: 2
@@ -58,7 +58,7 @@ spec:
         spec:
           containers:
           - name: llm
-            image: anyscale/rayllm:latest
+            image: anyscale/ray-llm:latest
             lifecycle:
               preStop:
                 exec:


### PR DESCRIPTION
I believe [this](https://hub.docker.com/r/anyscale/ray-llm) is the correct image, right? Basically `s/anyscale\/rayllm/anyscale\/ray-llm`.

Signed-off-by: Igor Hoelscher <igor.h@miro.com>