### PR TITLE
fix: no attribute 'set_url'

### DIFF
--- a/rayllm/frontend/app.py
+++ b/rayllm/frontend/app.py
@@ -495,7 +495,11 @@ app = AviaryFrontend.options(
             "env_vars": {
                 k: v
                 for k, v in os.environ.items()
-                if k.startswith("AVIARY") or k.startswith("OPENAI")
+                if (
+                    k.startswith("AVIARY")
+                    or k.startswith("OPENAI")
+                    or k.startswith("MONGO")
+                )
             }
         },
     },

--- a/rayllm/frontend/app.py
+++ b/rayllm/frontend/app.py
@@ -484,8 +484,8 @@ class AviaryFrontend(GradioIngress):
         )
         port = ray.get(controller.get_http_config.remote()).port
 
-        blocks._queue.set_url(f"http://localhost:{port}{route_prefix}/")
         blocks._queue.set_url = noop
+        blocks._queue.set_url(f"http://localhost:{port}{route_prefix}/")
 
 
 app = AviaryFrontend.options(


### PR DESCRIPTION
This fixes #89 

In addition fixes a separate, but related issue of frontend not accepting MONGODB_URL env variable.

I could not figure out why `frontend/aviary.js` is missing from the Docker. `MANIFEST.in` looks correct to me ...